### PR TITLE
Added necessary security string to the cookie assignment

### DIFF
--- a/docs/valentines-crossword-2024/script.js
+++ b/docs/valentines-crossword-2024/script.js
@@ -1058,7 +1058,7 @@ function saveProgress() {
             }
         }
     }
-    document.cookie = cookieName + '=' + saveString;
+    document.cookie = cookieName + '=' + saveString + "; SameSite=None; Secure";
 }
 
 function restoreProgress() {


### PR DESCRIPTION
The cookie saving did not work from within the  pym frame. 
Adding cookie options `SameSite=None` and `Secure` seems to fix it. 
Per https://stackoverflow.com/questions/51151183/cookie-not-being-set-in-iframe