### PR TITLE
Add new inputType

### DIFF
--- a/docs/valentines-crossword-2024/script.js
+++ b/docs/valentines-crossword-2024/script.js
@@ -789,7 +789,7 @@ for (let row = 0; row < crosswordGrid.length; row++) {
             cellAbove = parseInt(currentRow) - 1
 
             //LETTERS
-            if (event.inputType === 'insertText') {
+            if ((event.inputType === 'insertText') || (event.inputType === 'insertCompositionText')) {
                 const input = event.data.toUpperCase();
                 if (/^[A-Z]$/.test(input)) {
                     selectedCell.value = "";


### PR DESCRIPTION
Samsung default keyboard uses the `insertCompositionText` instead of `insertText` for `inputType`